### PR TITLE
Hide contact links on header and footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -15,16 +15,18 @@
                     <li>
                         <a class="page-scroll" href="#services">Services</a>
                     </li>
+                    {{ if isset .Site.Params "social" }}
                     <li class="footer-menu-divider">&sdot;</li>
                     <li>
                         <a class="page-scroll" href="#contact">Contact</a>
                     </li>
+                    {{ end }}
                 </ul>
                 <p class="copyright text-muted small">Copyright &copy; {{ .Title }} All Rights Reserved</p>
             </div>
             <div class="col-md-4">
 		Built with <a href="http://gohugo.io">Hugo</a> and the
-		<a href="https://github.com/crakjie/landing-page-hugo">landing-page-hugo</a> 
+		<a href="https://github.com/crakjie/landing-page-hugo">landing-page-hugo</a>
 		theme.
             </div>
         </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -20,9 +20,11 @@
                 <li>
                     <a class="page-scroll" href="#services">Services</a>
                 </li>
+                {{ if isset .Site.Params "social" }}
                 <li>
                     <a class="page-scroll" href="#contact">Contact</a>
                 </li>
+                {{ end }}
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -42,9 +44,11 @@
 			    <h1>{{ .Site.Title }}</h1>
 			    <h3>{{ .Site.Params.description }}</h3>
 			    <hr class="intro-divider">
+			    {{ if isset .Site.Params "social" }}
 			    <ul class="list-inline intro-social-buttons">
 				        {{ partial "social.html" . }}
 			    </ul>
+			    {{ end }}
 			</div>
 		    </div>
 		</div>


### PR DESCRIPTION
Hi, thank you for this great theme.

Now "Contact" links appear on header and footer even if `Params.social` is not set.
I modified header and footer to hide "Contact" links in that case.
