### PR TITLE
Fix documentation (custom css and services img)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Draft: false
 We specialize in bespoke widgets, built to your specification.
 ```
 
-Then place a matching image in `static/img/services/` - e.g. `static/img/services/widgets.png`
+Then place a matching image in `static/img/` - e.g. `static/img/widgets.png`
 
 ## Pricing Section
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Add custom CSS by specifying file(s) using `custom_css` param e.g. files such as
 
 ```toml
 [params]
-custom_css = ["css/local.css","css/media.css"]
+custom_css = ["/css/local.css","/css/media.css"]
 ```
 
 # Demo


### PR DESCRIPTION
Only 2 minor documentation changes.
Leading "/" for custom CSS and img URL for the services section.